### PR TITLE
Fixes to pathogen & gfortran installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,9 +442,9 @@ First, grab the special formulae (which are not part of Homebrew core):
     $ brew tap samueljohn/python
     $ brew tap homebrew/science
     
-Then, install the `gfortran` dependency which we will need to build the libraries:
+Then, install the `gfortran` dependency (now in `gcc`) which we will need to build the libraries:
 
-    $ brew install gfortran
+    $ brew install gcc
     
 Finally, you can install Numpy and Scipy with:
 


### PR DESCRIPTION
Previous instructions resulted in:

E117: Unknown function: pathogen#infect
E15: Invalid expression: pathogen#infect()
Press ENTER or type command to continue

New install instructions pulled from official 'vim-pathogen' README
