### PR TITLE
Updated iPython qtconsole instructions based on Spyder IDE issue #2608 …

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,16 +418,16 @@ Once it's done, we can install IPython with all the available options:
 
 You can launch IPython from the command line with `$ ipython`, but what's more interesting is to use its [QT Console](http://ipython.org/ipython-doc/stable/interactive/qtconsole.html). Launch the QT Console by running:
 
-    $ ipython qtconsole
+    $ jupyter qtconsole
     
 You can also customize the font it uses:
 
-    $ ipython qtconsole --ConsoleWidget.font_family="Consolas" --ConsoleWidget.font_size=13
+    $ jupyter qtconsole --ConsoleWidget.font_family="Consolas" --ConsoleWidget.font_size=13
     
 And since I'm lazy and I don't want to type or copy & paste that all the time, I'm going to create an alias for it. Create a `.extra` text file in your home directory with `$ subl ~/.extra` (I've set up `.bash_profile` to load `.extra`), and add the following line:
 
 ```bash
-alias ipy='ipython qtconsole --ConsoleWidget.font_family="Consolas" --ConsoleWidget.font_size=13'
+alias ipy='jupyter qtconsole --ConsoleWidget.font_family="Consolas" --ConsoleWidget.font_size=13'
 ```
     
 Open a fresh terminal. Now when you run `$ ipy`, it will launch the QT Console with your configured options.

--- a/README.md
+++ b/README.md
@@ -497,7 +497,13 @@ To connect with the command-line client, run:
 
 In terms of a GUI client for MySQL, I'm used to the official and free [MySQL Workbench](http://www.mysql.com/products/workbench/). But feel free to use whichever you prefer.
 
-You can find the MySQL Workbench download [here](http://www.mysql.com/downloads/workbench/). (**Note**: It will ask you to sign in, you don't need to, just click on "No thanks, just start my download!" at the bottom.)
+To install MySQL Workbench run: 
+
+    $ brew install Caskroom/cask/mysqlworkbench
+
+You can also find the MySQL Workbench download [here](http://www.mysql.com/downloads/workbench/). (**Note**: It will ask you to sign in, you don't need to, just click on "No thanks, just start my download!" at the bottom.)
+
+
 
 ## Node.js
 
@@ -699,7 +705,7 @@ Assuming that you have an account (sign up if you don't), let's install the [Her
     
 The formula might not have the latest version of the Heroku Client, which is updated pretty often. Let's update it now:
 
-    $ heroku update
+    $ brew upgrade heroku-toolbelt
     
 Don't be afraid to run `heroku update` every now and then to always have the most recent version.
 
@@ -747,7 +753,10 @@ In a terminal, start the MongoDB server:
 
     $ mongod
 
-In another terminal, connect to the database with the Mongo shell using:
+**Note** If you get an error "ailed to connect to 127.0.0.1:27017, reason: errno:61 Connection refused", try:
+    $ sudo mongod
+
+In another terminal (Cmd+T), connect to the database with the Mongo shell using:
 
     $ mongo
 


### PR DESCRIPTION
Updated iPython install instructions based on Spyder IDE issue #2608 at https://github.com/spyder-ide/spyder/issues/2626.  I kept getting an error:

"ImportError: No module named qtconsole.qtconsoleapp"

I'm using OS X 10.8.5, python 2.7.10.  
