### PR TITLE
Update .bash_prompt

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -45,7 +45,7 @@ export BOLD
 export RESET
 
 function parse_git_dirty() {
-  [[ $(git status 2> /dev/null | tail -n1) != *"working directory clean"* ]] && echo "*"
+  [[ $(git status 2> /dev/null | tail -n1) != *"working tree clean"* ]] && echo "*"
 }
 
 function parse_git_branch() {


### PR DESCRIPTION
Latest version of git output of `git status` is "working tree clean",
not "working directory clean".