### PR TITLE
Added global gitignore instructions for `.DS_Store`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ To push code to your GitHub repositories, we're going to use the recommended HTT
     
 **Note**: On a Mac, it is important to remember to add `.DS_Store` (a hidden OS X system file that's put in folders) to your `.gitignore` files. You can take a look at this repository's [.gitignore](https://github.com/nicolashery/mac-dev-setup/blob/master/.gitignore) file for inspiration.
     
+    $ cd ~
+    $ echo .DS_Store >> ~/.gitignore_global
+    $ git config --global core.excludesfile ~/.gitignore_global
+    
 ## Sublime Text
 
 With the terminal, the text editor is a developer's most important tool. Everyone has their preferences, but unless you're a hardcore [Vim](http://en.wikipedia.org/wiki/Vim_(text_editor)) user, a lot of people are going to tell you that [Sublime Text](http://www.sublimetext.com/) is currently the best one out there.


### PR DESCRIPTION
You can also create a global .gitignore file, which is a list of rules for ignoring files in every Git repository on your computer. For example, you might create the file at ~/.gitignore_global and add some rules to it. See: https://help.github.com/articles/ignoring-files/